### PR TITLE
Issue No. #174 [FIXED] On Resources page Practice links heading should be in Center.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -363,6 +363,7 @@
         <script src="script.js"></script>
         <script src="//code.tidio.co/jrwlyr4jlffbfwi1ogzqdzvxf34j4txb.js" async></script>
         <script src="./scrollTop.js"></script>
+        <script src="./copyrightYear.js"></script>
 </body>
 
 </html>

--- a/public/resources.css
+++ b/public/resources.css
@@ -97,7 +97,6 @@ body {
 .practice {
     display: block;
     width: 100vw;
-    margin-left: 45%;
     margin-top: 5%;
 }
 


### PR DESCRIPTION
Closes #174